### PR TITLE
fix:typo in HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,6 @@
             <td rowspan="2">CN</td>
             <td rowspan="2">DOS</td>  
         </tr>
-        tr>
             <td colspan="2">DAA lab</td>
         </tr>
         <tr>
@@ -103,7 +102,7 @@
             <td rowspan="2">DAA</td>
             <td rowspan="2">OS</td>  
         </tr>
-        tr>
+        
             <td colspan="2">DAA lab</td>
         </tr>
 


### PR DESCRIPTION
Fixing your tr typographic mistake  in HTML. You can see it in the HTML page in line 97 and 107.